### PR TITLE
🐛 removing '' from pakistan regex

### DIFF
--- a/lib/phone/pk.ex
+++ b/lib/phone/pk.ex
@@ -3,7 +3,7 @@ defmodule Phone.PK do
 
   use Helper.Country
 
-  def regex, do: ~r/^(92)()(.+'')/
+  def regex, do: ~r/^(92)()(.+)/
   def country, do: "Pakistan"
   def a2, do: "PK"
   def a3, do: "PAK"


### PR DESCRIPTION
fix unknown '' regex for pakistan phone number