### PR TITLE
✨ solve monaco parsing issue

### DIFF
--- a/lib/phone/mc.ex
+++ b/lib/phone/mc.ex
@@ -3,7 +3,7 @@ defmodule Phone.MC do
 
   use Helper.Country
 
-  def regex, do: ~r/^(377)()(.{9})/
+  def regex, do: ~r/^(377)()(.{8})/
   def country, do: "Monaco"
   def a2, do: "MC"
   def a3, do: "MCO"


### PR DESCRIPTION
according to https://en.wikipedia.org/wiki/Telephone_numbers_in_Monaco, Telephone numbers in Monaco are eight digits in length